### PR TITLE
Event 엔티티에 상태 패턴 적용

### DIFF
--- a/src/main/java/com/dokev/gold_dduck/event/domain/Event.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/Event.java
@@ -146,52 +146,31 @@ public class Event extends BaseEntity {
         this.leftBlankCount--;
     }
 
+    public void runEvent() {
+        this.eventProgressStatus = EventProgressStatus.RUNNING;
+    }
+
     public void closeEvent() {
         this.eventProgressStatus = EventProgressStatus.CLOSED;
     }
 
-    public void validateEndTime() {
-        boolean eventEndTimeOver = this.endAt.isBefore(LocalDateTime.now());
-        if (eventEndTimeOver) {
-            closeEvent();
-            throw new EventClosedException();
-        }
-    }
-
-    public void validateCloseStatus() {
-        if (this.eventProgressStatus == EventProgressStatus.CLOSED) {
-            throw new EventClosedException();
-        }
-    }
-
     public void validateEventRunning() {
+        renewStatus();
         validateCloseStatus();
-        validateEndTime();
     }
 
     public void renewStatus() {
-        if (this.eventProgressStatus == EventProgressStatus.CLOSED) {
-            return;
-        }
-        if (this.giftChoiceType == GiftChoiceType.FIFO && this.leftGiftCount <= 0) {
-            closeEvent();
-            return;
-        }
-        if (this.giftChoiceType == GiftChoiceType.RANDOM && this.leftGiftCount + this.leftBlankCount <= 0) {
-            closeEvent();
-            return;
-        }
-        if (startAt.isEqual(LocalDateTime.now()) || (startAt.isBefore(LocalDateTime.now()) && endAt.isAfter(
-            LocalDateTime.now()))) {
-            eventProgressStatus = EventProgressStatus.RUNNING;
-            return;
-        }
-        if (endAt.isEqual(LocalDateTime.now()) || endAt.isBefore(LocalDateTime.now())){
-            eventProgressStatus = EventProgressStatus.CLOSED;
-        }
+        this.eventProgressStatus.getEventStatus().renew(this);
     }
 
     public void deleteEvent() {
         this.deletedAt = LocalDateTime.now();
     }
+
+    private void validateCloseStatus() {
+        if (this.eventProgressStatus == EventProgressStatus.CLOSED) {
+            throw new EventClosedException();
+        }
+    }
+
 }

--- a/src/main/java/com/dokev/gold_dduck/event/domain/EventProgressStatus.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/EventProgressStatus.java
@@ -1,5 +1,20 @@
 package com.dokev.gold_dduck.event.domain;
 
+import com.dokev.gold_dduck.event.domain.status.ClosedStatus;
+import com.dokev.gold_dduck.event.domain.status.EventStatus;
+import com.dokev.gold_dduck.event.domain.status.ReadyStatus;
+import com.dokev.gold_dduck.event.domain.status.RunningStatus;
+import lombok.Getter;
+
+@Getter
 public enum EventProgressStatus {
-    READY, RUNNING, CLOSED
+    READY(new ReadyStatus()),
+    RUNNING(new RunningStatus()),
+    CLOSED(new ClosedStatus());
+
+    private final EventStatus eventStatus;
+
+    EventProgressStatus(EventStatus eventStatus) {
+        this.eventStatus = eventStatus;
+    }
 }

--- a/src/main/java/com/dokev/gold_dduck/event/domain/status/ClosedStatus.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/status/ClosedStatus.java
@@ -1,0 +1,25 @@
+package com.dokev.gold_dduck.event.domain.status;
+
+import com.dokev.gold_dduck.event.domain.Event;
+import com.dokev.gold_dduck.event.domain.GiftChoiceType;
+import java.time.LocalDateTime;
+
+public class ClosedStatus implements EventStatus {
+
+    @Override
+    public boolean canChange(Event event) {
+        return checkGiftStock(event) || checkCloseTime(event);
+    }
+
+    private boolean checkGiftStock(Event event) {
+        boolean isFifoGiftSoldOut = event.getGiftChoiceType() == GiftChoiceType.FIFO && event.getLeftGiftCount() <= 0;
+        boolean isRandomGiftSoldOut = event.getGiftChoiceType() == GiftChoiceType.RANDOM
+            && event.getLeftGiftCount() + event.getLeftBlankCount() <= 0;
+        return isFifoGiftSoldOut || isRandomGiftSoldOut;
+    }
+
+    private boolean checkCloseTime(Event event) {
+        return event.getEndAt().isEqual(LocalDateTime.now()) || event.getEndAt().isBefore(LocalDateTime.now());
+    }
+
+}

--- a/src/main/java/com/dokev/gold_dduck/event/domain/status/EventStatus.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/status/EventStatus.java
@@ -1,0 +1,15 @@
+package com.dokev.gold_dduck.event.domain.status;
+
+import com.dokev.gold_dduck.event.domain.Event;
+
+public interface EventStatus {
+
+    default void renew(Event event) {
+
+    }
+
+    default boolean canChange(Event event) {
+        return false;
+    }
+
+}

--- a/src/main/java/com/dokev/gold_dduck/event/domain/status/ReadyStatus.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/status/ReadyStatus.java
@@ -1,0 +1,21 @@
+package com.dokev.gold_dduck.event.domain.status;
+
+import static com.dokev.gold_dduck.event.domain.EventProgressStatus.CLOSED;
+import static com.dokev.gold_dduck.event.domain.EventProgressStatus.RUNNING;
+
+import com.dokev.gold_dduck.event.domain.Event;
+
+public class ReadyStatus implements EventStatus {
+
+    @Override
+    public void renew(Event event) {
+        if (CLOSED.getEventStatus().canChange(event)) {
+            event.closeEvent();
+            return;
+        }
+        if (RUNNING.getEventStatus().canChange(event)) {
+            event.runEvent();
+        }
+    }
+
+}

--- a/src/main/java/com/dokev/gold_dduck/event/domain/status/RunningStatus.java
+++ b/src/main/java/com/dokev/gold_dduck/event/domain/status/RunningStatus.java
@@ -1,0 +1,22 @@
+package com.dokev.gold_dduck.event.domain.status;
+
+import static com.dokev.gold_dduck.event.domain.EventProgressStatus.CLOSED;
+
+import com.dokev.gold_dduck.event.domain.Event;
+import java.time.LocalDateTime;
+
+public class RunningStatus implements EventStatus {
+
+    @Override
+    public void renew(Event event) {
+        if (CLOSED.getEventStatus().canChange(event)) {
+            event.closeEvent();
+        }
+    }
+
+    @Override
+    public boolean canChange(Event event) {
+        return event.getStartAt().isEqual(LocalDateTime.now()) || (event.getStartAt().isBefore(LocalDateTime.now())
+            && event.getEndAt().isAfter(LocalDateTime.now()));
+    }
+}


### PR DESCRIPTION
## ⁉ 문제 발생

금나와라뚝딱(이하 금뚝)의 Event 엔티티는 `Ready` `Running` `Closed` 세가지의 상태를 가질 수 있다. 이벤트는 Ready 상태로 시작해서 이벤트 오픈시간이 되면 Running 상태로 바뀌고 선물 재고가 없거나 종료시간이 되면 Closed 상태로 변경된다. **하지만 분명 Closed된 Event 엔티티가 자꾸 Running 상태로 변경되는 문제가 발생했다.** ... (보다 자세한 설명은 [노션에 정리해두었습니다](https://delirious-sock-4dc.notion.site/Event-b59852337fc64458a1018d7d66b4e39b))

close #4 